### PR TITLE
better eslint, new retry events

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,9 +22,10 @@
     "no-unused-expressions": [2, { "allowShortCircuit": true, "allowTernary": true }],
     "no-return-await": [2],
     "consistent-return": [2],
-    "semi": [2, "always"],
     "default-case-last": [2],
     "@typescript-eslint/await-thenable": [2],
-    "@typescript-eslint/no-unused-vars": [2]
+    "@typescript-eslint/no-unused-vars": [2],
+    "semi": "off",
+    "@typescript-eslint/semi": [2]
   }
 }

--- a/docs/content/api/module/retry.md
+++ b/docs/content/api/module/retry.md
@@ -21,7 +21,12 @@ const circuit = new Circuit({
       new Retry({
         attempts: 2, // Will retry two times
         interval: 500, // Will wait 500ms between attempts
-        onRejection: (err) => { // Can help filtering error and modifying the retry behavior
+        onRejection: (err, attempt) => { // Can help filtering error and modifying the retry behavior
+          // Second parameter represent the current attempt
+          // In this example, onRejection will be called 3 times
+          // attempt = 0: first failure
+          // attempt = 1: first retry failure
+          // attempt = 2: second retry failure
           if (err instanceof BrokenError) {
             return false; // Returning false will cancel the retry attempt
           } else if (err instanceof BusyError) {
@@ -46,13 +51,17 @@ const circuit = new Circuit({
 
 ## Events
 
-| Name       | Description                          | Params                                                      |
-|:-----------|:-------------------------------------|:------------------------------------------------------------|
-| `execute`  | Called when the module is executed.  | `Mollitia.Circuit` **circuit**                              |
-| `retry`    | Called when retrying.                | `Mollitia.Circuit` **circuit**, `number` **currentAttempt** |
+| Name                    | Description                                            | Params                                                      |
+|:------------------------|:-------------------------------------------------------|:------------------------------------------------------------|
+| `execute`               | Called when the module is executed.                    | `Mollitia.Circuit` **circuit**                              |
+| `retry`                 | Called when retrying.                                  | `Mollitia.Circuit` **circuit**, `number` **currentAttempt** |
+| `success-without-retry` | Called the module execution succeeds without retrying. | `Mollitia.Circuit` **circuit**                              |
+| `success-with-retry`    | Called the module execution succeeds after retrying.   | `Mollitia.Circuit` **circuit**, `number` **attempts**       |
+| `failure-without-retry` | Called the module execution fails without retrying.    | `Mollitia.Circuit` **circuit**                              |
+| `failure-with-retry`    | Called the module execution fails after retrying.      | `Mollitia.Circuit` **circuit**, `number` **attempts**       |
 
 ## Methods
 
-| Name       | Description                          | Returns                         |
-|:-----------|:-------------------------------------|:-------------------------------|
-| `getExecParams`  | Returns the circuit function parameters.  | `any[]` **params** |
+| Name             | Description                              | Returns                       |
+|:-----------------|:-----------------------------------------|:------------------------------|
+| `getExecParams`  | Returns the circuit function parameters. | `any[]` **params**            |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mollitia",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mollitia",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "JavaScript Resilience Library",
   "main": "dist/mollitia.umd.js",
   "module": "dist/mollitia.es5.js",
@@ -36,6 +36,7 @@
     "fault-handling"
   ],
   "scripts": {
+    "install:all": "npm i && cd ./docs && npm i",
     "dev": "npm run build:lib && run-p dev:lib dev:docs",
     "dev:lib": "run-p dev:lib:tsc dev:lib:rollup",
     "dev:lib:tsc": "tsc --watch --module commonjs",

--- a/src/module/breaker/index.ts
+++ b/src/module/breaker/index.ts
@@ -9,7 +9,7 @@ type BreakerResultResponse = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   response: any;
   shouldReportFailure: boolean;
-}
+};
 
 /**
  * Returned when a breaker module is in open state.
@@ -203,7 +203,7 @@ export abstract class SlidingWindowBreaker<T> extends Module {
         default:
         return this.executeInClosed(promise, ...params);
     }
-  } 
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   abstract executeInClosed<T1> (promise: CircuitFunction, ...params: any[]): Promise<T1>;
@@ -221,7 +221,7 @@ export abstract class SlidingWindowBreaker<T> extends Module {
       this.nbCallsInHalfOpenedState++;
       const {requestResult, response, shouldReportFailure } = await this.executePromise(promise, ...params);
       this.callsInHalfOpenedState.push(this.adjustedRequestResult(requestResult, shouldReportFailure));
-    
+
       if (this.callsInHalfOpenedState.length == this.permittedNumberOfCallsInHalfOpenState) {
         this.checkCallRatesHalfOpen(this.open.bind(this), this.close.bind(this));
       }

--- a/src/module/retry.ts
+++ b/src/module/retry.ts
@@ -3,7 +3,7 @@ import { Circuit, CircuitFunction } from '../circuit';
 import { delay } from '../helpers/time';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type RetryCallback = (err: any) => boolean|number;
+type RetryCallback = (err: any, attempt: number) => boolean|number;
 
 /**
  * Properties that customizes the retry behavior.
@@ -61,23 +61,55 @@ export class Retry extends Module {
   private async _promiseRetry<T> (circuit: Circuit, attempts: number, promise: CircuitFunction, ...params: any[]): Promise<T> {
     if (attempts - 1 === 0) {
       this.emit('retry', circuit, this.attempts);
-      this.logger?.debug(`${circuit.name}/${this.name} - Retry: (${this.attempts}/${this.attempts})`);
-      return promise(...params);
+      if (this.attempts) {
+        this.logger?.debug(`${circuit.name}/${this.name} - Retry: (${this.attempts}/${this.attempts})`);
+      }
+      return promise(...params)
+        .then((res) => {
+          if (this.attempts > 0) {
+            this.emit('success-with-retry', circuit, this.attempts);
+          } else {
+            this.emit('success-without-retry', circuit);
+          }
+          return res;
+        })
+        .catch((err) => {
+          if (this.attempts > 0) {
+            this.emit('failure-with-retry', circuit, this.attempts);
+          } else {
+            this.emit('failure-without-retry', circuit);
+          }
+          throw err;
+        });
     }
     if (attempts !== (this.attempts + 1)) {
       this.emit('retry', circuit, this.attempts - attempts + 1);
       this.logger?.debug(`${circuit.name}/${this.name} - Retry: (${this.attempts - attempts + 1}/${this.attempts})`);
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return promise(...params).catch(async (err: any) => {
-      const shouldRetry = this.onRejection(err);
-      const interval = (typeof shouldRetry === 'number') ? shouldRetry : this.interval;
-      if (shouldRetry === false) {
-        return Promise.reject(err);
-      } else {
-        await delay(interval);
-        return this._promiseRetry(circuit, (attempts - 1), promise, ...params);
-      }
-    });
+    return promise(...params)
+      .then((res) => {
+        if (attempts !== (this.attempts + 1)) {
+          this.emit('success-with-retry', circuit, this.attempts - attempts + 1);
+        } else {
+          this.emit('success-without-retry', circuit);
+        }
+        return res;
+      })
+      .catch(async (err) => {
+        const shouldRetry = this.onRejection(err, this.attempts - attempts + 1);
+        const interval = (typeof shouldRetry === 'number') ? shouldRetry : this.interval;
+        if (shouldRetry === false) {
+          if (attempts !== (this.attempts + 1)) {
+            this.emit('failure-with-retry', circuit, this.attempts - attempts + 1);
+          } else {
+            this.emit('failure-without-retry', circuit);
+          }
+          return Promise.reject(err);
+        } else {
+          await delay(interval);
+          return this._promiseRetry(circuit, (attempts - 1), promise, ...params);
+        }
+      });
   }
 }

--- a/src/module/retry.ts
+++ b/src/module/retry.ts
@@ -60,8 +60,8 @@ export class Retry extends Module {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async _promiseRetry<T> (circuit: Circuit, attempts: number, promise: CircuitFunction, ...params: any[]): Promise<T> {
     if (attempts - 1 === 0) {
-      this.emit('retry', circuit, this.attempts);
       if (this.attempts) {
+        this.emit('retry', circuit, this.attempts);
         this.logger?.debug(`${circuit.name}/${this.name} - Retry: (${this.attempts}/${this.attempts})`);
       }
       return promise(...params)

--- a/test/unit/module/retry.spec.ts
+++ b/test/unit/module/retry.spec.ts
@@ -136,21 +136,7 @@ describe('Retry', () => {
     await delay(1000);
     expect(onRetry).toHaveBeenNthCalledWith(2, circuit, 2);
   });
-  it('should emit events for retries', async () => {
-    let currentAttempts = 0;
-    const successAsyncAfterNth = jest.fn().mockImplementation((attempts, res: unknown = 'default', delay = 1) => {
-      return new Promise((resolve, reject) => {
-        setTimeout(() => {
-          if (currentAttempts !== attempts) {
-            currentAttempts++;
-            reject(res);
-          } else {
-            currentAttempts = 0;
-            resolve(res);
-          }
-        }, delay);
-      });
-    });
+  it('should emit success-without-retry events for retries', async () => {
     const retry = new Mollitia.Retry({
       attempts: 0,
       interval: 100
@@ -175,13 +161,80 @@ describe('Retry', () => {
     expect(onSuccessWithoutRetry).toHaveBeenNthCalledWith(1, circuit);
     retry.attempts = 1;
     await circuit.fn(successAsync).execute('dummy', 100);
+    retry.attempts = 2;
+    await circuit.fn(successAsync).execute('dummy', 100);
+    expect(onSuccessWithoutRetry).toHaveBeenNthCalledWith(1, circuit);
     expect(onSuccessWithoutRetry).toHaveBeenNthCalledWith(2, circuit);
+    expect(onSuccessWithoutRetry).toHaveBeenNthCalledWith(3, circuit);
+    expect(onSuccessWithRetry).not.toHaveBeenCalled();
+    expect(onFailuresWithoutRetry).not.toHaveBeenCalled();
+    expect(onFailuresWithRetry).not.toHaveBeenCalled();
+  });
+  it('should emit success-with-retry events for retries', async () => {
+    let currentAttempts = 0;
+    const successAsyncAfterNth = jest.fn().mockImplementation((attempts, res: unknown = 'default', delay = 1) => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          if (currentAttempts !== attempts) {
+            currentAttempts++;
+            reject(res);
+          } else {
+            currentAttempts = 0;
+            resolve(res);
+          }
+        }, delay);
+      });
+    });
+    const retry = new Mollitia.Retry({
+      attempts: 1,
+      interval: 100
+    });
+    const onSuccessWithoutRetry = jest.fn();
+    retry.on('success-without-retry', onSuccessWithoutRetry);
+    const onSuccessWithRetry = jest.fn();
+    retry.on('success-with-retry', onSuccessWithRetry);
+    const onFailuresWithoutRetry = jest.fn();
+    retry.on('failure-without-retry', onFailuresWithoutRetry);
+    const onFailuresWithRetry = jest.fn();
+    retry.on('failure-with-retry', onFailuresWithRetry);
+    const circuit = new Mollitia.Circuit({
+      options: {
+        modules: [
+          retry
+        ]
+      }
+    });
     // Success With Retries
     await circuit.fn(successAsyncAfterNth).execute(1, 'dummy', 100);
     expect(onSuccessWithRetry).toHaveBeenNthCalledWith(1, circuit, 1);
     retry.attempts = 2;
     await circuit.fn(successAsyncAfterNth).execute(1, 'dummy', 100);
+    expect(onSuccessWithRetry).toHaveBeenNthCalledWith(1, circuit, 1);
     expect(onSuccessWithRetry).toHaveBeenNthCalledWith(2, circuit, 1);
+    expect(onSuccessWithoutRetry).not.toHaveBeenCalled();
+    expect(onFailuresWithoutRetry).not.toHaveBeenCalled();
+    expect(onFailuresWithRetry).not.toHaveBeenCalled();
+  });
+  it('should emit failure-without-retry events for retries', async () => {
+    const retry = new Mollitia.Retry({
+      attempts: 0,
+      interval: 100
+    });
+    const onSuccessWithoutRetry = jest.fn();
+    retry.on('success-without-retry', onSuccessWithoutRetry);
+    const onSuccessWithRetry = jest.fn();
+    retry.on('success-with-retry', onSuccessWithRetry);
+    const onFailuresWithoutRetry = jest.fn();
+    retry.on('failure-without-retry', onFailuresWithoutRetry);
+    const onFailuresWithRetry = jest.fn();
+    retry.on('failure-with-retry', onFailuresWithRetry);
+    const circuit = new Mollitia.Circuit({
+      options: {
+        modules: [
+          retry
+        ]
+      }
+    });
     // Failure Without Retries
     retry.attempts = 0;
     await expect(circuit.fn(failureAsync).execute('dummy', 100)).rejects.toEqual('dummy');
@@ -189,7 +242,35 @@ describe('Retry', () => {
     retry.attempts = 1;
     retry.onRejection = () => false;
     await expect(circuit.fn(failureAsync).execute('dummy', 100)).rejects.toEqual('dummy');
+    retry.attempts = 2;
+    await expect(circuit.fn(failureAsync).execute('dummy', 100)).rejects.toEqual('dummy');
+    expect(onFailuresWithoutRetry).toHaveBeenNthCalledWith(1, circuit);
     expect(onFailuresWithoutRetry).toHaveBeenNthCalledWith(2, circuit);
+    expect(onFailuresWithoutRetry).toHaveBeenNthCalledWith(3, circuit);
+    expect(onSuccessWithoutRetry).not.toHaveBeenCalled();
+    expect(onSuccessWithRetry).not.toHaveBeenCalled();
+    expect(onFailuresWithRetry).not.toHaveBeenCalled();
+  });
+  it('should emit failure-with-retry events for retries', async () => {
+    const retry = new Mollitia.Retry({
+      attempts: 1,
+      interval: 100
+    });
+    const onSuccessWithoutRetry = jest.fn();
+    retry.on('success-without-retry', onSuccessWithoutRetry);
+    const onSuccessWithRetry = jest.fn();
+    retry.on('success-with-retry', onSuccessWithRetry);
+    const onFailuresWithoutRetry = jest.fn();
+    retry.on('failure-without-retry', onFailuresWithoutRetry);
+    const onFailuresWithRetry = jest.fn();
+    retry.on('failure-with-retry', onFailuresWithRetry);
+    const circuit = new Mollitia.Circuit({
+      options: {
+        modules: [
+          retry
+        ]
+      }
+    });
     // Failure With Retries
     retry.onRejection = () => true;
     await expect(circuit.fn(failureAsync).execute('dummy', 100)).rejects.toEqual('dummy');
@@ -201,5 +282,8 @@ describe('Retry', () => {
     };
     await expect(circuit.fn(failureAsync).execute('dummy', 100)).rejects.toEqual('dummy');
     expect(onFailuresWithRetry).toHaveBeenNthCalledWith(2, circuit, 1);
+    expect(onSuccessWithoutRetry).not.toHaveBeenCalled();
+    expect(onSuccessWithRetry).not.toHaveBeenCalled();
+    expect(onFailuresWithoutRetry).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This adds a few events to the `retry` module.
This will allow the [@mollitia/prometheus](https://github.com/genesys/mollitia-prometheus) plugin to add multiple metrics to this module.