### PR TITLE
Documentation: Fix options table on timeout module page

### DIFF
--- a/docs/src/guide/api/modules/timeout.md
+++ b/docs/src/guide/api/modules/timeout.md
@@ -44,7 +44,7 @@ circuit.fn(myLongFunction).execute()
 ### Options
 
 | Name     | Description                                          | Default |
-|:---------|:------------------------------------------------ ----|:--------|
+|:---------|:-----------------------------------------------------|:--------|
 | `delay`  | The amount of time before a the promise is rejected. | `60000` |
 
 ### Methods


### PR DESCRIPTION
Fixes the options table in the Timeout module documentation.